### PR TITLE
Update Require Illuminate Version To `9.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "keywords": ["laravel", "hotwire", "turbo"],
     "license": "MIT",
     "require": {
-        "illuminate/container": "^8.54",
-        "illuminate/contracts": "^8.40",
-        "illuminate/support": "^8.40",
-        "illuminate/view": "^8.54"
+        "illuminate/container": "^9.1",
+        "illuminate/contracts": "^9.1",
+        "illuminate/support": "^9.1",
+        "illuminate/view": "^9.1"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
### Changed version to `9.1`

- "**illuminate/container**"
  - source: https://packagist.org/packages/illuminate/container

- "**illuminate/contracts**"
  - source: https://packagist.org/packages/illuminate/contracts

- "**illuminate/support**"
  - source: https://packagist.org/packages/illuminate/support

- "**illuminate/view**"
  - source: https://packagist.org/packages/illuminate/view